### PR TITLE
PR - Edited weapons to adjust some translations

### DIFF
--- a/2_translated/menu/Compdata.xml
+++ b/2_translated/menu/Compdata.xml
@@ -9087,7 +9087,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>304892,304896,305036,305040,305180,305184,306008,306012,306224,306228,306440,306444</PointerOffset>
       <JapaneseText>バーレイ・サイズ</JapaneseText>
-      <EnglishText>Burleigh Scythe</EnglishText>
+      <EnglishText>Barley Scythe</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -9143,7 +9143,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>307268,307272,307448,307452,307700,307704,307880,307884,308060,308064</PointerOffset>
       <JapaneseText>ギーグ・ガン</JapaneseText>
-      <EnglishText>Gigue Gun</EnglishText>
+      <EnglishText>Geeg Gun</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -9159,7 +9159,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>307340,307344,307520,307524,307772,307776,307952,307956,308132,308136</PointerOffset>
       <JapaneseText>ライアット・ジャレンチ</JapaneseText>
-      <EnglishText>Riot G-Wrench</EnglishText>
+      <EnglishText>Riot GiaWrench</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>


### PR DESCRIPTION
There were some weapon names that needed to be revisited, mostly because of clarification around official translations for the Gunleon's weapons.