### PR TITLE
PR - Edited weapons to reduce lengthy weapon names

### DIFF
--- a/2_translated/menu/Compdata.xml
+++ b/2_translated/menu/Compdata.xml
@@ -3898,7 +3898,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Scarlet Beam (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>208304,208308,208412,208416</PointerOffset>
@@ -3986,7 +3986,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Photon Power Missile</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>209744,209748,209888,209892</PointerOffset>
@@ -3994,7 +3994,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Photon Power Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>209960,209964,210068,210072</PointerOffset>
@@ -4122,7 +4122,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Small Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>211904,211908</PointerOffset>
@@ -4130,7 +4130,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Double Missile</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>211940,211944</PointerOffset>
@@ -4138,7 +4138,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Double Cutter</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>211976,211980</PointerOffset>
@@ -4146,7 +4146,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Double Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>212012,212016</PointerOffset>
@@ -4178,7 +4178,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Marine Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>212228,212232,212444,212448</PointerOffset>
@@ -4202,7 +4202,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Drill Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>212588,212592,212804,212808</PointerOffset>
@@ -4234,7 +4234,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Vegatron Beam (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213164,213168,213308,213312,213416,213420,216476,216480,216584,216588,217736,217740,222164,222168</PointerOffset>
@@ -4250,7 +4250,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Vegatron Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213236,213240</PointerOffset>
@@ -4266,7 +4266,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Vegatron Beam Cannon (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213488,213492,213560,213564</PointerOffset>
@@ -4282,7 +4282,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Super Vegatron Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213632,213636,214208,214212,214820,214824,215468,215472,215684,215688</PointerOffset>
@@ -4298,7 +4298,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Double Tomahawk Boomerang</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213704,213708,214280,214284,214892,214896,215540,215544,215756,215760</PointerOffset>
@@ -4314,7 +4314,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Getter Beam (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213776,213780,214352,214356,214964,214968,215612,215616,215828,215832</PointerOffset>
@@ -4354,7 +4354,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Liger Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>213956,213960,214568,214572,215216,215220</PointerOffset>
@@ -4386,7 +4386,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Strong Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>214136,214140,214748,214752,215396,215400</PointerOffset>
@@ -4426,7 +4426,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Command Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>216188,216192,216296,216300</PointerOffset>
@@ -4434,7 +4434,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Vulcan Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>216368,216372,221552,221556,221660,221664,225980,225984,226268,226272,226592,226596,226772,226776,226952,226956,227276,227280,229472,229476,229652,229656,229832,229836,230012,230016,230192,230196,230372,230376,230552,230556,230732,230736,230876,230880,231272,231276,231488,231492,231704,231708,231920,231924,232100,232104,232316,232320,232640,232644,232856,232860,232964,232968,233072,233076,233180,233184,233288,233292,233396,233400,233504,233508,233612,233616,233720,233724,233828,233832,233936,233940,234044,234048,234152,234156,234656,234660,234800,234804,234944,234948,235088,235092,235232,235236,235376,235380,235520,235524,235664,235668,236168,236172,236312,236316,236456,236460,237068,237072,254132,254136,254276,254280,281312,281316,281456,281460,281600,281604,281744,281748,281888,281892,282032,282036,282176,282180,282932,282936,283040,283044,283148,283152,283256,283260,283364,283368,283472,283476,283580,283584,283688,283692,283796,283800,283904,283908,284012,284016,284120,284124,284228,284232,284336,284340,284948,284952,285092,285096,285236,285240,285380,285384,285632,285636,285740,285744,285848,285852,285956,285960,286064,286068,286172,286176,286280,286284,286388,286392,286496,286500,286604,286608,286748,286752,287000,287004,287180,287184,287432,287436,287720,287724,287972,287976,288836,288840,288944,288948,289052,289056,289124,289128,289196,289200,289304,289308,289628,289632,290204,290208,290600,290604,293912,293916,294020,294024,300752,300756,300788,300792,300824,300828,300860,300864,301328,301332,312992,312996,313064,313068,313244,313248</PointerOffset>
@@ -4466,7 +4466,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>216656,216660,216800,216804,216944,216948,217088,217092,217232,217236</PointerOffset>
@@ -4506,7 +4506,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hyakki Fighter Team-Up</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>217772,217776</PointerOffset>
@@ -4610,7 +4610,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Laser Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>219140,219144,223820,223824,223928,223932,224180,224184</PointerOffset>
@@ -4650,7 +4650,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Destruction Beam (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>219392,219396,219500,219504,219608,219612</PointerOffset>
@@ -4746,7 +4746,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Sigma Breast Matchless Blade</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>220796,220800</PointerOffset>
@@ -4770,7 +4770,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>221300,221304,221408,221412</PointerOffset>
@@ -4794,7 +4794,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Fang Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>221516,221520,221624,221628</PointerOffset>
@@ -4810,7 +4810,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Flame Shot (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>221732,221736,221840,221844</PointerOffset>
@@ -4834,7 +4834,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Dissolving Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>221984,221988,222056,222060,222128,222132</PointerOffset>
@@ -4946,7 +4946,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Tremble Horn (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>223712,223716</PointerOffset>
@@ -4970,7 +4970,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Zambo Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>223892,223896,224000,224004,293156,293160,293228,293232</PointerOffset>
@@ -4978,7 +4978,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Laser (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>224036,224040</PointerOffset>
@@ -5010,7 +5010,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Particle Laser (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>224360,224364</PointerOffset>
@@ -5034,7 +5034,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Shield Beam (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>224468,224472</PointerOffset>
@@ -5178,7 +5178,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Grenade Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>227816,227820,227924,227928,228032,228036,231308,231312,231524,231528,231740,231744,234620,234624,234764,234768,234908,234912,235052,235056,298952,298956,299384,299388</PointerOffset>
@@ -5194,7 +5194,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Missile Launcher (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>228428,228432,228500,228504,231092,231096,255572,255576,255644,255648,255716,255720</PointerOffset>
@@ -5226,7 +5226,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Machine Gun (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>228644,228648,228716,228720,228824,228828,228932,228936,229076,229080,229220,229224,229364,229368</PointerOffset>
@@ -5242,7 +5242,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Machine Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>228968,228972,229112,229116,229256,229260,229400,229404</PointerOffset>
@@ -5250,7 +5250,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>90mm Rapid Grenade Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>229004,229008,229148,229152,229292,229296,229436,229440</PointerOffset>
@@ -5258,7 +5258,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hi-Power Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>229544,229548,229724,229728,229904,229908,230084,230088,230804,230808,230948,230952,313136,313140</PointerOffset>
@@ -5274,7 +5274,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Triple Shot Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>230264,230268,230444,230448,230624,230628,313316,313320</PointerOffset>
@@ -5290,7 +5290,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Pistol (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>231128,231132,288692,288696,288800,288804</PointerOffset>
@@ -5330,7 +5330,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Dedicated Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>231956,231960,232136,232140,232352,232356</PointerOffset>
@@ -5386,7 +5386,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Triple Timed Heat Howitzer​s</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>232532,232536,232676,232680,232820,232824,236960,236964,237104,237108</PointerOffset>
@@ -5418,7 +5418,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Missile Pod (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>233324,233328,233432,233436,233540,233544,233648,233652,233756,233760,233864,233868</PointerOffset>
@@ -5434,7 +5434,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Rocket Vulcan (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>234260,234264,234368,234372,234476,234480</PointerOffset>
@@ -5458,7 +5458,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Napalm Gun (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>235160,235164,235304,235308,235448,235452,235592,235596,312920,312924</PointerOffset>
@@ -5482,7 +5482,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Rocket Pod (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>235736,235740,235844,235848,235952,235956,236060,236064,284444,284448,284552,284556</PointerOffset>
@@ -5522,7 +5522,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Rifle (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>236276,236280,236420,236424,236564,236568</PointerOffset>
@@ -5618,7 +5618,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>237320,237324,237572,237576,237788,237792,238436,238440,238652,238656</PointerOffset>
@@ -5626,7 +5626,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hyper Bazooka (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>237356,237360,237608,237612,237824,237828,238472,238476,238688,238692</PointerOffset>
@@ -5730,7 +5730,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Pistol (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>242972,242976,243044,243048,243152,243156,243260,243264,243332,243336</PointerOffset>
@@ -5746,7 +5746,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Arm Beam Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>243404,243408,243512,243516,243620,243624,243728,243732,243836,243840</PointerOffset>
@@ -5754,7 +5754,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Zaku Machine Gun Custom</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>243476,243480,243584,243588,243692,243696,243800,243804,243908,243912</PointerOffset>
@@ -5762,7 +5762,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Zaku M. G. Custom (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>244592,244596,244700,244704,244808,244812</PointerOffset>
@@ -5778,7 +5778,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Rifle (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>245276,245280,245384,245388,245492,245496,245672,245676,245816,245820,245960,245964,245996,246000,246140,246144,246284,246288,246896,246900,247004,247008,248444,248448,248480,248484,248588,248592,248624,248628,248840,248844,248876,248880,248948,248952,249020,249024,249092,249096,249164,249168,249236,249240,254636,254744,255608,255612,255680,255684,255752,255756,255824,255828,255896,255900</PointerOffset>
@@ -5794,7 +5794,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Mega Particle Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>246068,246072,246212,246216,246356,246360</PointerOffset>
@@ -5810,7 +5810,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Fedayeen Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>246464,246468,246608,246612</PointerOffset>
@@ -5858,7 +5858,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>247400,247404,247472,247476,247580,247584,247724,247728,247868,247872,260396,260400,260504,260508,260612,260616,278000,288656,288660,288764,288768,294416,294420,294524,294528,294668,294672,294776,294780,294956,294960,295172,295176,295388,295392,295604,295608,295856,295860,296072,296076,296324,296328,296576,296580,296792,296796,297044,297048,297224,297228,297440,297444,297728,297732,297980,297984,298196,298200,298304,298308,300356,300360,300464,300468,300572,300576</PointerOffset>
@@ -5882,7 +5882,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>248084,248088,248228,248232</PointerOffset>
@@ -6010,7 +6010,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Missile (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>252116,252120,254456,254460,254564,254568</PointerOffset>
@@ -6050,7 +6050,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Machine Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>252264,252408,252552,252696,252840</PointerOffset>
@@ -6058,7 +6058,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Borjarnon Machine Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>252296,252300,252440,252444,252584,252588,252728,252732,252872,252876</PointerOffset>
@@ -6090,7 +6090,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hand Beam Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>253016,253020,253160,253164,253304,253308,253484,253488,253664,253668,253844,253848</PointerOffset>
@@ -6114,7 +6114,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Autocannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>253952,253956,254060,254064</PointerOffset>
@@ -6138,7 +6138,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Huge Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>254204,254208,254348,254352</PointerOffset>
@@ -6170,7 +6170,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Toroidal Shield M. P. Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>254676,254784</PointerOffset>
@@ -6178,7 +6178,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>T. S. M. P. Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>254816,254820,254960,254964</PointerOffset>
@@ -6202,7 +6202,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Triple Beam Projector System</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>255176,255180,255320,255324,255500,255504</PointerOffset>
@@ -6250,7 +6250,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Buster Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>256076,256080,256112,256116,256328,256332,256364,256368,256940,256944,256976,256980</PointerOffset>
@@ -6266,7 +6266,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Shield Buster Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>256292,256296,256724,256728,258272,258276,258884,258888</PointerOffset>
@@ -6290,7 +6290,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Machine Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>256544,256760,257156,257160</PointerOffset>
@@ -6306,7 +6306,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Divider 13-Barrel Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>257192,257196,257372,257376,257912,257916,258128,258132,258380,258384,258668,258672,258992,258996,259208,259212</PointerOffset>
@@ -6322,7 +6322,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Buster Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>257264,257268,257444,257448</PointerOffset>
@@ -6410,7 +6410,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Homing Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>260072,260076,260216,260220</PointerOffset>
@@ -6450,7 +6450,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Claw Beam (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>260792,260796,260972,260976,261152,261156,261332,261336,261548,261692,261836,261980,261984</PointerOffset>
@@ -6490,7 +6490,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Scissor Beam Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>261512,261516,261656,261660,261800,261804,261944,261948</PointerOffset>
@@ -6546,7 +6546,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Newtype-Use Wired Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>263168,263172,263240,263244</PointerOffset>
@@ -6578,7 +6578,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Bazooka (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>263708,263888,264032,264212,264428,264572,264752,264968,265112,265292,265436,265652,265868,271808,271988,272168,272348,272528,272708,272888,273068,273248,273428</PointerOffset>
@@ -6602,7 +6602,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR72 Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>263784,264288,264828,265512,265728,265944,271848,272028,272208,272388,272568,272748,272964,273144,273324,273504</PointerOffset>
@@ -6626,7 +6626,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR72 Beam Rifle</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>263960,264500,265040,265364,273680,273932</PointerOffset>
@@ -6642,7 +6642,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>RQM60 Flash Edge Beam Boomerang</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>263996,264392,264536,264932,265076,265400,265616,265832,266048</PointerOffset>
@@ -6738,7 +6738,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Assault Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>266160,266268,266412,266556,266700,266844,266988,267132,267276,267420,267564,267708</PointerOffset>
@@ -6746,7 +6746,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MMI-M633 Beam Assault Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>266300,266444,266588,266732,266876</PointerOffset>
@@ -6770,7 +6770,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Assault Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>267020,267164,267308,267452,267596,267740</PointerOffset>
@@ -6818,7 +6818,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>M181SE Draupnir Quad Beam Gun</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>267852,267996,268140,268284,268428</PointerOffset>
@@ -6826,7 +6826,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>M181SE Draupnir Quad Beam Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>267884,268028,268172,268316,268460</PointerOffset>
@@ -6874,7 +6874,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-M21G Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>268712,268820</PointerOffset>
@@ -6898,7 +6898,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Beam Carbine (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>268784,268892</PointerOffset>
@@ -6962,7 +6962,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Close Range Auto-Turret</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>269148,269292,269652,269832,270012,270192</PointerOffset>
@@ -6970,7 +6970,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>M2M5 Todesschrecken 12.5mm Close Range Auto-Defense Turret</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>269184,269328,269688,269868,270048,270228</PointerOffset>
@@ -7002,7 +7002,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Low-Recoil Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>269256,269400</PointerOffset>
@@ -7010,7 +7010,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Mk-39 Low-Recoil Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>269432,269540</PointerOffset>
@@ -7034,7 +7034,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Linear Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>269504,269612</PointerOffset>
@@ -7058,7 +7058,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Twin Linear Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>269724,269904,270084,270264</PointerOffset>
@@ -7114,7 +7114,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR721 Hi-Energy Beam Rifle</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>270480,270660,270840,271020</PointerOffset>
@@ -7122,7 +7122,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR721 Hi-En Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>270512,270692,270872,271052</PointerOffset>
@@ -7242,7 +7242,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR70 Hi-Energy Beam Rifle</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>273000,273180,273360,273540</PointerOffset>
@@ -7250,7 +7250,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR70 Hi-En Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>273032,273212,273392,273572</PointerOffset>
@@ -7298,7 +7298,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>RQM60F Flash Edge 2 Beam Boomerang</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>273720,273972</PointerOffset>
@@ -7306,7 +7306,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-BAR73/S Hi-En Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>273752,274004</PointerOffset>
@@ -7314,7 +7314,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hi-En Long Range Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>273756,274008</PointerOffset>
@@ -7330,7 +7330,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Arondight</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>273792,274044</PointerOffset>
@@ -7370,7 +7370,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Dragoon System (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>274224,274404</PointerOffset>
@@ -7378,7 +7378,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Separable Integrated-Control High-Mobility Weapon Pod Network System (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>274256,274436</PointerOffset>
@@ -7434,7 +7434,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-M20 Lupus Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>274616,274620,274796,274800,274976,274980,275156,275160</PointerOffset>
@@ -7482,7 +7482,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-M21KF Hi-En Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>275340,275664</PointerOffset>
@@ -7546,7 +7546,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>MA-M1911 Hi-En Beam Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>275912,276200</PointerOffset>
@@ -7586,7 +7586,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>M2M5D 12.5mm Close Range Auto Turret</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>276312,276492,276672,276852</PointerOffset>
@@ -7610,7 +7610,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Type 73J2 Experimental Twin Beam Saber</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>276384,276564,276744,276924</PointerOffset>
@@ -7618,7 +7618,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Type 72D5 Beam Rifle Hyakurai (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>276416,276776,277100,277244,278108</PointerOffset>
@@ -7682,7 +7682,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Type 72 Kai Beam Rifle Ikazuchi (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>277712,277856</PointerOffset>
@@ -7754,7 +7754,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>M464 Degtyaryov Hi-En Beam Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>278144,278148</PointerOffset>
@@ -7762,7 +7762,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hi-Energy Beam Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>278180,278288</PointerOffset>
@@ -7978,7 +7978,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Rivet Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>281420,281424,281564,281568,281708,281712,281852,281856,281996,282000,282140,282144,282284,282288</PointerOffset>
@@ -7994,7 +7994,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Rapid-Fire Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>282392,282396,282536,282540,282680,282684,282860,282864</PointerOffset>
@@ -8090,7 +8090,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Hand Gun (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>285056,285060,285200,285204,285344,285348,285488,285492</PointerOffset>
@@ -8130,7 +8130,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Max Thunder (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>285884,285888,285992,285996,286100,286104</PointerOffset>
@@ -8490,7 +8490,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Gravity Arrow (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>292688,292692,292832,292836,293084,293088</PointerOffset>
@@ -8522,7 +8522,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Spear Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>293372,293376,293516,293520</PointerOffset>
@@ -8546,7 +8546,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Energy Shot (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>293696,293700,293768,293772</PointerOffset>
@@ -8738,7 +8738,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Impact Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>298520,298524,298736,298740,299132,299136</PointerOffset>
@@ -8770,7 +8770,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>GUN Pod (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>298844,298848,299276,299280</PointerOffset>
@@ -8794,7 +8794,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Claw (Spread)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>299456,299460,299672,299676,299744,299748,299816,299820,299852,299856,299924,299928,299960,299964,300032,300036,300068,300072,300140,300144,300248,300252</PointerOffset>
@@ -8866,7 +8866,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Spike Missile (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>300896,300900,301004,301008,301148,301152,301400,301404,301544,301548,301652,301656,301760,301764,301868,301872,301976,301980,302120,302124</PointerOffset>
@@ -8922,7 +8922,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Long Range Laser Cannon (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>302264,302268,302408,302412</PointerOffset>
@@ -9282,7 +9282,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Pulsar Rifle (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>309392,309396,309536,309540,309680,309684</PointerOffset>
@@ -9306,7 +9306,7 @@ It's considered an antique now.</EnglishText>
       <EnglishText>Pulsar Shot (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
-      <Status>Editing</Status>
+      <Status>Proofreading</Status>
     </Entry>
     <Entry>
       <PointerOffset>309788,309792</PointerOffset>


### PR DESCRIPTION
Did a full pass through the translated weapon names and made the following changes:
- Changed all instances of "(Rapid Fire)" to "(Rapid)".
- Changed all instances of "(Spread Shot)" to "(Spread)".
- Made changes to shorten some of the longest weapon names, mostly by abbreviating words, e.g. "High-Energy Long Range Beam Cannon" => "Hi-En Long Range Beam Cannon".

**This should still only be considered a preliminary review.** The following concerns remain:
- More playtesting will probably reveal more changes are needed, specifically:
- Some of the longest weapon names may still need to be shortened further.
- There are some extraordinarily long strings in the weapons file which I believe are going to appear somewhere with more generous space constraints, e.g. "M2M5 Todesschrecken 12.5mm Close Range Auto-Defense Turret". Whenever I noticed these, I just left them alone. We may need to circle back once we see these in playtesting and have a better grasp on how much space we're working with.