### PR TITLE
PR - Shortened more weapon names

### DIFF
--- a/2_translated/menu/Compdata.xml
+++ b/2_translated/menu/Compdata.xml
@@ -7399,7 +7399,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>274472,274652,274832,275012,275192,275516</PointerOffset>
       <JapaneseText>近接防御機関砲</JapaneseText>
-      <EnglishText>Close Range Defense Autocannon</EnglishText>
+      <EnglishText>Defensive Autocannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -7639,7 +7639,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>276596,276956</PointerOffset>
       <JapaneseText>誘導機動ビーム砲塔システム</JapaneseText>
-      <EnglishText>Guided Mobile Beam Cannon System</EnglishText>
+      <EnglishText>Guided Beam Cannon System</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -8039,7 +8039,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>283652,283656,283760,283764,283868,283872,283976,283980,284084,284088,284192,284196,284300,284304,284408,284412</PointerOffset>
       <JapaneseText>２００ミリロケットアシスト砲</JapaneseText>
-      <EnglishText>200mm Rocket-Assisted Cannon</EnglishText>
+      <EnglishText>200mm Rocket Assist Cannon</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -8455,7 +8455,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>291428,291432,292040,292044</PointerOffset>
       <JapaneseText>超重炎皇斬</JapaneseText>
-      <EnglishText>Super Heavy Flame Emperor Slash</EnglishText>
+      <EnglishText>Heavyweight Emperor Slash</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -8679,7 +8679,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>295352,295356,296036,296040,296756,296760,297404,297408,298160,298164,298988,298992</PointerOffset>
       <JapaneseText>逆念写爆破</JapaneseText>
-      <EnglishText>Reverse Psycho-Photography Blast</EnglishText>
+      <EnglishText>Psycography Bomb</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -8919,7 +8919,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>301832,301836,301940,301944,302048,302052,302192,302196,302336,302340,302480,302484</PointerOffset>
       <JapaneseText>ロングレンジレーザー砲（連射）</JapaneseText>
-      <EnglishText>Long Range Laser Cannon (Rapid)</EnglishText>
+      <EnglishText>Long Range Laser (Rapid)</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>
@@ -8951,7 +8951,7 @@ It's considered an antique now.</EnglishText>
     <Entry>
       <PointerOffset>302624,302628,302732,302736</PointerOffset>
       <JapaneseText>トラパルザー砲一斉発射</JapaneseText>
-      <EnglishText>Trapulsar Cannon Simultaneous Fire</EnglishText>
+      <EnglishText>Trapulsar Cannon Full Burst</EnglishText>
       <Notes/>
       <Chapter>Uncategorized</Chapter>
       <Status>Proofreading</Status>


### PR DESCRIPTION
Playtesting revealed four weapon names that were still over the space limits. Based on the length of the problematic entries, I reviewed the whole list again and identified three more that were probably also still too long. I updated all seven so that all should now hopefully fit within constraints. **I want to continue to emphasize there are still many very long entries in the weapons data, but all that remain are because their in-game context is not yet fully understood and I decided it was premature to make drastic changes to them.**